### PR TITLE
Add SmartAPI trading service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # tradingbot-smartAPI
+
+This project exposes a FastAPI service for receiving TradingView webhooks and placing orders through Angel One's SmartAPI. Tokens are stored in Google Cloud Storage and open positions are tracked in Redis. Order updates are listened to over a WebSocket connection.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Set the following environment variables:
+
+- `SMARTAPI_API_KEY`
+- `SMARTAPI_CLIENT_CODE`
+- `SMARTAPI_PASSWORD`
+- `SMARTAPI_TOTP`
+- `GCS_BUCKET` – Google Cloud Storage bucket name for persisting session tokens
+- `REDIS_HOST` / `REDIS_PORT` / `REDIS_DB`
+
+Ensure Google Cloud credentials are available (e.g. `GOOGLE_APPLICATION_CREDENTIALS`).
+
+## Running
+
+```bash
+uvicorn main:app --reload
+```
+
+Endpoints:
+
+- `POST /auth/login` – authenticate with SmartAPI
+- `POST /auth/logout` – logout and clear session
+- `POST /webhook` – TradingView webhook endpoint

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+from smartapi_wrapper import get_wrapper
+
+router = APIRouter()
+
+
+@router.post("/login")
+async def login():
+    wrapper = get_wrapper()
+    session = wrapper.login()
+    return {"status": "success", "data": session.get("data")}
+
+
+@router.post("/logout")
+async def logout():
+    wrapper = get_wrapper()
+    wrapper.logout()
+    return {"status": "logged out"}

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,23 @@
+import json
+import logging
+import sys
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_record = {
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers.clear()
+    root.addHandler(handler)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,20 @@
+import logging
+
+from fastapi import FastAPI
+
+import logging_config
+from auth import router as auth_router
+from smartapi_wrapper import get_wrapper
+from webhook import router as webhook_router
+
+logging_config.setup_logging()
+
+app = FastAPI()
+app.include_router(auth_router, prefix="/auth")
+app.include_router(webhook_router)
+
+
+@app.on_event("startup")
+async def start_websocket():
+    wrapper = get_wrapper()
+    wrapper.start_websocket(wrapper.default_update_handler)

--- a/orders.py
+++ b/orders.py
@@ -1,0 +1,19 @@
+from typing import Any, Dict
+
+
+def from_tradingview(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert TradingView webhook payload to SmartAPI order parameters."""
+    return {
+        "variety": data.get("variety", "NORMAL"),
+        "tradingsymbol": data["symbol"],
+        "symboltoken": data.get("token"),
+        "transactiontype": data.get("side", "BUY"),
+        "exchange": data.get("exchange", "NSE"),
+        "ordertype": data.get("order_type", "MARKET"),
+        "producttype": data.get("product_type", "INTRADAY"),
+        "duration": data.get("duration", "DAY"),
+        "price": data.get("price"),
+        "squareoff": data.get("squareoff"),
+        "stoploss": data.get("stoploss"),
+        "quantity": int(data.get("qty", 1)),
+    }

--- a/redis_client.py
+++ b/redis_client.py
@@ -1,0 +1,30 @@
+import os
+import redis
+
+_redis_client = None
+
+
+def get_client() -> redis.Redis:
+    global _redis_client
+    if _redis_client is None:
+        host = os.getenv("REDIS_HOST", "localhost")
+        port = int(os.getenv("REDIS_PORT", 6379))
+        db = int(os.getenv("REDIS_DB", 0))
+        _redis_client = redis.Redis(host=host, port=port, db=db, decode_responses=True)
+    return _redis_client
+
+
+def set_position(symbol: str, qty: int) -> None:
+    get_client().set(symbol, qty)
+
+
+def get_position(symbol: str) -> int:
+    val = get_client().get(symbol)
+    return int(val) if val is not None else 0
+
+
+def update_position(symbol: str, qty_delta: int) -> int:
+    current = get_position(symbol)
+    new_qty = current + qty_delta
+    set_position(symbol, new_qty)
+    return new_qty

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+smartapi-python
+google-cloud-storage
+redis
+python-dotenv
+logzero
+websocket-client

--- a/smartapi_wrapper.py
+++ b/smartapi_wrapper.py
@@ -1,0 +1,123 @@
+import json
+import logging
+import os
+from threading import Thread
+from typing import Any, Callable, Dict, Optional
+
+from google.cloud import storage
+from SmartApi import SmartConnect
+from SmartApi.smartWebSocketOrderUpdate import SmartWebSocketOrderUpdate
+
+from redis_client import update_position
+
+logger = logging.getLogger(__name__)
+
+
+class SmartAPIWrapper:
+    """Wrapper around SmartConnect handling token storage and order updates."""
+
+    def __init__(self) -> None:
+        self.api_key = os.getenv("SMARTAPI_API_KEY")
+        self.client_code = os.getenv("SMARTAPI_CLIENT_CODE")
+        self.password = os.getenv("SMARTAPI_PASSWORD")
+        self.totp = os.getenv("SMARTAPI_TOTP")
+        self.gcs_bucket_name = os.getenv("GCS_BUCKET")
+        self.token_file = "smartapi_token.json"
+        self.smart: Optional[SmartConnect] = None
+        self.session: Optional[Dict[str, Any]] = None
+        self.ws_thread: Optional[Thread] = None
+        self.websocket = None
+
+    # Google Cloud Storage helpers
+    def _bucket(self) -> storage.bucket.Bucket:
+        client = storage.Client()
+        return client.bucket(self.gcs_bucket_name)
+
+    def _save_token(self, token: Dict[str, Any]) -> None:
+        if not self.gcs_bucket_name:
+            return
+        blob = self._bucket().blob(self.token_file)
+        blob.upload_from_string(json.dumps(token))
+        logger.info("Stored token to GCS")
+
+    def _load_token(self) -> Optional[Dict[str, Any]]:
+        if not self.gcs_bucket_name:
+            return None
+        blob = self._bucket().blob(self.token_file)
+        if blob.exists():
+            data = blob.download_as_bytes()
+            return json.loads(data.decode())
+        return None
+
+    # Authentication
+    def login(self) -> Dict[str, Any]:
+        self.smart = SmartConnect(api_key=self.api_key)
+        token = self._load_token()
+        if token:
+            self.smart.set_session(token["data"]["jwtToken"])
+            self.session = token
+            logger.info("Loaded SmartAPI session from storage")
+            return token
+        session = self.smart.generateSession(self.client_code, self.password, self.totp)
+        self.session = session
+        self._save_token(session)
+        logger.info("Generated new SmartAPI session")
+        return session
+
+    def logout(self) -> None:
+        if self.smart:
+            try:
+                self.smart.logout()
+            except Exception as exc:
+                logger.error("Logout failed: %s", exc)
+        self.session = None
+
+    # Orders
+    def place_order(self, params: Dict[str, Any]) -> Any:
+        if not self.smart or not self.session:
+            self.login()
+        resp = self.smart.placeOrder(params)
+        logger.info("Order response: %s", resp)
+        return resp
+
+    # Websocket
+    def _run_ws(self, on_update: Callable[[str], None]) -> None:
+        token = self.session["data"]["feedToken"]
+        jwt = self.session["data"]["jwtToken"]
+        ws = SmartWebSocketOrderUpdate(jwt, self.api_key, self.client_code, token)
+        ws.on_message = lambda wsapp, msg: on_update(msg)
+        ws.connect()
+
+    def start_websocket(self, on_update: Callable[[str], None]) -> None:
+        if not self.smart or not self.session:
+            self.login()
+        if self.ws_thread and self.ws_thread.is_alive():
+            return
+        self.ws_thread = Thread(target=self._run_ws, args=(on_update,), daemon=True)
+        self.ws_thread.start()
+
+    def default_update_handler(self, message: str) -> None:
+        """Handle order update messages and track positions in Redis."""
+        logger.info("Order update: %s", message)
+        try:
+            data = json.loads(message)
+            symbol = data.get("tradingsymbol") or data.get("symboltoken")
+            qty = int(data.get("quantity", 0))
+            txn = data.get("transactiontype")
+            if symbol and qty:
+                if txn == "BUY":
+                    update_position(symbol, qty)
+                elif txn == "SELL":
+                    update_position(symbol, -qty)
+        except Exception as exc:
+            logger.error("Failed to process order update: %s", exc)
+
+
+_wrapper: Optional[SmartAPIWrapper] = None
+
+
+def get_wrapper() -> SmartAPIWrapper:
+    global _wrapper
+    if _wrapper is None:
+        _wrapper = SmartAPIWrapper()
+    return _wrapper

--- a/webhook.py
+++ b/webhook.py
@@ -1,0 +1,22 @@
+import logging
+from fastapi import APIRouter, HTTPException, Request
+
+from orders import from_tradingview
+from smartapi_wrapper import get_wrapper
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.post("/webhook")
+async def tradingview_webhook(payload: Request):
+    try:
+        data = await payload.json()
+    except Exception as exc:
+        logger.error("Invalid payload: %s", exc)
+        raise HTTPException(status_code=400, detail="invalid payload")
+
+    wrapper = get_wrapper()
+    order_params = from_tradingview(data)
+    resp = wrapper.place_order(order_params)
+    return {"status": "order_sent", "response": resp}


### PR DESCRIPTION
## Summary
- implement FastAPI server with webhook and auth endpoints
- integrate SmartAPI and store token in Google Cloud Storage
- track positions in Redis and log in JSON
- add websocket listener for order updates

## Testing
- `python -m py_compile *.py`
- `pip install smartapi-python google-cloud-storage redis fastapi uvicorn python-dotenv logzero websocket-client`
- `python -m uvicorn main:app --port 8000 --reload` *(fails: Invalid Token)*

------
https://chatgpt.com/codex/tasks/task_e_687d4be07ecc8328befce97dfe8e4e75