### PR TITLE
Add pytest and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,12 @@ Ensure the Cloud Run service account can access the GCS bucket storing the Smart
 
 ## Testing
 
-No automated tests are included. You can verify the environment with:
+Install the dependencies and run the test suite with `pytest`:
 
 ```bash
-python -m compileall .
+pip install -r requirements.txt
+pytest
 ```
-
-If you add tests, run them using `pytest`.
 
 ## Running the WebSocket Listener Manually
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ redis
 python-dotenv
 logzero
 websocket-client
+pytest
+httpx

--- a/tests/test_smartapi_wrapper.py
+++ b/tests/test_smartapi_wrapper.py
@@ -1,0 +1,62 @@
+import pytest
+
+import smartapi_wrapper
+
+class DummySmart:
+    def __init__(self, *args, **kwargs):
+        self.session_set = None
+        self.generated = False
+        self.ordered = None
+
+    def set_session(self, token):
+        self.session_set = token
+
+    def generateSession(self, client_code, password, totp):
+        self.generated = True
+        return {"data": {"jwtToken": "jwt", "feedToken": "feed"}}
+
+    def placeOrder(self, params):
+        self.ordered = params
+        return {"order": "ok"}
+
+    def logout(self):
+        pass
+
+
+def test_login_uses_stored_token(monkeypatch):
+    token = {"data": {"jwtToken": "t1", "feedToken": "f1"}}
+    monkeypatch.setattr(smartapi_wrapper, "SmartConnect", DummySmart)
+    wrapper = smartapi_wrapper.SmartAPIWrapper()
+    monkeypatch.setattr(wrapper, "_load_token", lambda: token)
+    called = {}
+    monkeypatch.setattr(wrapper, "_save_token", lambda t: called.setdefault("saved", t))
+
+    session = wrapper.login()
+    assert session == token
+    assert wrapper.smart.session_set == "t1"
+    assert "saved" not in called
+
+
+def test_login_generates_token(monkeypatch):
+    monkeypatch.setattr(smartapi_wrapper, "SmartConnect", DummySmart)
+    wrapper = smartapi_wrapper.SmartAPIWrapper()
+    monkeypatch.setattr(wrapper, "_load_token", lambda: None)
+    saved = {}
+    monkeypatch.setattr(wrapper, "_save_token", lambda t: saved.setdefault("token", t))
+
+    session = wrapper.login()
+    assert wrapper.smart.generated
+    assert saved["token"] == session
+    assert wrapper.session == session
+
+
+def test_place_order_triggers_login(monkeypatch):
+    monkeypatch.setattr(smartapi_wrapper, "SmartConnect", DummySmart)
+    wrapper = smartapi_wrapper.SmartAPIWrapper()
+    monkeypatch.setattr(wrapper, "_load_token", lambda: {"data": {"jwtToken": "t", "feedToken": "f"}})
+    monkeypatch.setattr(wrapper, "_save_token", lambda t: None)
+
+    resp = wrapper.place_order({"key": "val"})
+    assert wrapper.session is not None  # login was called
+    assert wrapper.smart.ordered == {"key": "val"}
+    assert resp == {"order": "ok"}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,57 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import main
+
+class DummyWrapper:
+    def __init__(self):
+        self.placed = None
+        self.started = False
+
+    def place_order(self, params):
+        self.placed = params
+        return {"order_id": "123"}
+
+    def start_websocket(self, handler):
+        self.started = True
+
+    def default_update_handler(self, msg):
+        pass
+
+
+@pytest.fixture
+def client(monkeypatch):
+    wrapper = DummyWrapper()
+    monkeypatch.setattr("smartapi_wrapper.get_wrapper", lambda: wrapper)
+    monkeypatch.setattr(main, "get_wrapper", lambda: wrapper)
+    import webhook
+    monkeypatch.setattr(webhook, "get_wrapper", lambda: wrapper)
+    app = main.app
+    return TestClient(app)
+
+
+def test_webhook_invalid_json(client):
+    response = client.post("/webhook", data="notjson", headers={"Content-Type": "application/json"})
+    assert response.status_code == 400
+
+
+def test_webhook_valid_request(client):
+    payload = {"symbol": "SBIN-EQ", "qty": 1}
+    response = client.post("/webhook", json=payload)
+    assert response.status_code == 200
+    wrapper = main.get_wrapper()
+    assert wrapper.placed == {
+        "variety": "NORMAL",
+        "tradingsymbol": "SBIN-EQ",
+        "symboltoken": None,
+        "transactiontype": "BUY",
+        "exchange": "NSE",
+        "ordertype": "MARKET",
+        "producttype": "INTRADAY",
+        "duration": "DAY",
+        "price": None,
+        "squareoff": None,
+        "stoploss": None,
+        "quantity": 1,
+    }
+


### PR DESCRIPTION
## Summary
- add pytest and httpx to requirements
- document running tests in README
- provide tests for SmartAPI wrapper logic
- provide tests for webhook endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5117275483288ec1d4e9d0a2399b