### PR TITLE
Pin httpx for TestClient compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+Dependencies pin `httpx<0.25` to remain compatible with `starlette.TestClient`.
+
 ## Configuration
 
 Copy `.env.example` to `.env` and set the following environment variables:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ python-dotenv
 logzero
 websocket-client
 pytest
-httpx
+httpx<0.25


### PR DESCRIPTION
## Summary
- pin httpx<0.25 in requirements
- mention httpx pin in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e057eedac83289d686a53815d9285