### PR TITLE
Improve websocket startup resiliency

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import logging
+import asyncio
 
 from fastapi import FastAPI
 
@@ -14,7 +15,25 @@ app.include_router(auth_router, prefix="/auth")
 app.include_router(webhook_router)
 
 
+logger = logging.getLogger(__name__)
+
+
 @app.on_event("startup")
 async def start_websocket():
     wrapper = get_wrapper()
-    wrapper.start_websocket(wrapper.default_update_handler)
+    attempts = 3
+    for attempt in range(1, attempts + 1):
+        try:
+            wrapper.start_websocket(wrapper.default_update_handler)
+            break
+        except Exception as exc:
+            logger.exception(
+                "WebSocket start failed (attempt %s/%s): %s",
+                attempt,
+                attempts,
+                exc,
+            )
+            if attempt < attempts:
+                await asyncio.sleep(2)
+    else:
+        logger.error("Could not establish WebSocket connection")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,25 @@
+import asyncio
+import logging
+import main
+import smartapi_wrapper
+
+class FailingWrapper:
+    def __init__(self):
+        self.calls = 0
+    def start_websocket(self, handler):
+        self.calls += 1
+        raise Exception('boom')
+    def default_update_handler(self, msg):
+        pass
+
+
+def test_startup_websocket_failure_logged(monkeypatch, caplog):
+    wrapper = FailingWrapper()
+    monkeypatch.setattr(smartapi_wrapper, 'get_wrapper', lambda: wrapper)
+    monkeypatch.setattr(main, 'get_wrapper', lambda: wrapper)
+
+    with caplog.at_level(logging.ERROR):
+        asyncio.run(main.start_websocket())
+
+    assert wrapper.calls >= 1
+    assert any('WebSocket start failed' in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- handle exceptions when starting the websocket on startup
- retry websocket connection before giving up
- test that failed websocket connections are logged without crashing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e590efbe083288648f927f08e274e