### PR TITLE
Handle login errors

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,15 +1,20 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+import logging
 
 from smartapi_wrapper import get_wrapper
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.post("/login")
 async def login():
     wrapper = get_wrapper()
     session = wrapper.login()
-    return {"status": "success", "data": session.get("data")}
+    if "error" in session:
+        logger.error("Login failed: %s", session["error"])
+        raise HTTPException(status_code=502, detail=session["error"])
+    return {"status": "success", "data": session["data"]}
 
 
 @router.post("/logout")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -12,9 +12,25 @@ class DummyWrapper:
     def logout(self):
         self.logged_out = True
 
+
+class FailingWrapper(DummyWrapper):
+    def login(self):
+        return {"error": "boom"}
+
 @pytest.fixture
 def auth_client(monkeypatch):
     wrapper = DummyWrapper()
+    monkeypatch.setattr("smartapi_wrapper.get_wrapper", lambda: wrapper)
+    import auth
+    monkeypatch.setattr(auth, "get_wrapper", lambda: wrapper)
+    monkeypatch.setattr(main, "get_wrapper", lambda: wrapper)
+    app = main.app
+    return TestClient(app)
+
+
+@pytest.fixture
+def failing_auth_client(monkeypatch):
+    wrapper = FailingWrapper()
     monkeypatch.setattr("smartapi_wrapper.get_wrapper", lambda: wrapper)
     import auth
     monkeypatch.setattr(auth, "get_wrapper", lambda: wrapper)
@@ -33,3 +49,9 @@ def test_logout_endpoint(auth_client):
     resp = auth_client.post("/auth/logout")
     assert resp.status_code == 200
     assert resp.json()["status"] == "logged out"
+
+
+def test_login_error_returns_502(failing_auth_client):
+    resp = failing_auth_client.post("/auth/login")
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "boom"


### PR DESCRIPTION
## Summary
- improve `/auth/login` to return 502 on error
- test login error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f66ee10e4832890eca8c625412d3e