### PR TITLE
Improve order login handling

### DIFF
--- a/smartapi_wrapper.py
+++ b/smartapi_wrapper.py
@@ -92,7 +92,15 @@ class SmartAPIWrapper:
     # Orders
     def place_order(self, params: Dict[str, Any]) -> Any:
         if not self.smart or not self.session:
-            self.login()
+            login_res = self.login()
+            if isinstance(login_res, dict) and "error" in login_res:
+                logger.error("Login failed: %s", login_res["error"])
+                return login_res
+
+        if not self.smart or not self.session:
+            logger.error("SmartAPI session not established")
+            return {"error": "login failed"}
+
         try:
             resp = self.smart.placeOrder(params)
         except Exception as exc:

--- a/tests/test_smartapi_wrapper.py
+++ b/tests/test_smartapi_wrapper.py
@@ -140,6 +140,17 @@ def test_login_returns_error_on_smartconnect_failure(monkeypatch, caplog):
     assert any("Failed to login to SmartAPI" in r.message for r in caplog.records)
 
 
+def test_place_order_returns_login_error(monkeypatch, caplog):
+    wrapper = smartapi_wrapper.SmartAPIWrapper()
+    monkeypatch.setattr(wrapper, "login", lambda: {"error": "bad"})
+
+    with caplog.at_level(logging.ERROR):
+        resp = wrapper.place_order({"k": "v"})
+
+    assert resp == {"error": "bad"}
+    assert any("Login failed" in r.message for r in caplog.records)
+
+
 def test_default_update_handler_buy_and_sell(monkeypatch):
     wrapper = smartapi_wrapper.SmartAPIWrapper()
     calls = []


### PR DESCRIPTION
## Summary
- handle errors from `login()` in `place_order`
- extend SmartAPI wrapper tests with login error case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6a77d5d8832898d4cab653b373d2