### PR TITLE
Ensure websocket thread cleared on stop

### DIFF
--- a/tests/test_smartapi_wrapper.py
+++ b/tests/test_smartapi_wrapper.py
@@ -272,3 +272,31 @@ def test_start_websocket_sets_websocket(monkeypatch):
 
     assert isinstance(wrapper.websocket, DummyWS)
     assert wrapper.websocket.connected
+
+
+def test_stop_websocket_clears_state(monkeypatch):
+    wrapper = smartapi_wrapper.SmartAPIWrapper()
+    wrapper.smart = object()
+    wrapper.session = {'data': {'feedToken': 'f', 'jwtToken': 'j'}}
+    monkeypatch.setattr(smartapi_wrapper, 'Thread', DummyThread)
+
+    class DummyWS:
+        def __init__(self, *args, **kwargs):
+            self.closed = False
+        def connect(self):
+            pass
+        def close_connection(self):
+            self.closed = True
+
+    monkeypatch.setattr(smartapi_wrapper, 'SmartWebSocketOrderUpdate', DummyWS)
+
+    wrapper.start_websocket(lambda x: None)
+
+    ws = wrapper.websocket
+    assert wrapper.ws_thread is not None
+
+    wrapper.stop_websocket()
+
+    assert ws.closed
+    assert wrapper.websocket is None
+    assert wrapper.ws_thread is None

--- a/tradingbot/services/smartapi_wrapper.py
+++ b/tradingbot/services/smartapi_wrapper.py
@@ -134,6 +134,7 @@ class SmartAPIWrapper:
             except Exception as exc:
                 logger.error("Failed to close WebSocket: %s", exc)
         self.websocket = None
+        self.ws_thread = None
 
     def default_update_handler(self, message: str) -> None:
         """Handle order update messages and track positions in Redis."""


### PR DESCRIPTION
## Summary
- make `stop_websocket` clear the websocket thread
- add unit test verifying thread and websocket are cleared

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887477540cc83288c34e00c70aed5e1