### PR TITLE
Handle error dict from webhook order

### DIFF
--- a/tradingbot/routers/webhook.py
+++ b/tradingbot/routers/webhook.py
@@ -23,4 +23,7 @@ async def tradingview_webhook(payload: Request):
     except Exception as exc:
         logger.exception("Failed to place order: %s", exc)
         raise HTTPException(status_code=502, detail=str(exc))
+    if isinstance(resp, dict) and "error" in resp:
+        logger.error("Order error: %s", resp["error"])
+        raise HTTPException(status_code=502, detail=resp["error"])
     return {"status": "order_sent", "response": resp}


### PR DESCRIPTION
## Summary
- handle SmartAPI error responses in webhook
- test that error dict from wrapper leads to HTTP 502

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688756e71ae083289621190463b40b5b